### PR TITLE
Fix path handling and update testing to allow changing the GS path on an .env file

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+GS_BIN_PATH='/opt/homebrew/bin/gs'

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+GS_BIN_PATH='/usr/bin/gs'

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
   },
   "require-dev": {
     "phpunit/phpunit": ">7.0",
-    "symfony/var-dumper": "^6.4"
+    "symfony/var-dumper": "^6.4",
+    "vlucas/phpdotenv": "^5.6"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     "php": ">7.1"
   },
   "require-dev": {
-    "phpunit/phpunit": ">7.0"
+    "phpunit/phpunit": ">7.0",
+    "symfony/var-dumper": "^6.4"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     }
   ],
   "require": {
-    "php": ">7.1"
+    "php": ">7.1",
+    "ext-fileinfo": "*"
   },
   "require-dev": {
     "phpunit/phpunit": ">7.0",

--- a/src/Cores/FileSystem.php
+++ b/src/Cores/FileSystem.php
@@ -21,7 +21,7 @@ class FileSystem
      */
     public function isDir(string $path): bool
     {
-        return ($path && is_dir(trim(trim($path, '"'), "'")));
+        return ($path && is_dir($path));
     }
 
     /**
@@ -31,6 +31,6 @@ class FileSystem
      */
     public function isFile(string $path): bool
     {
-        return ($path && is_file(trim(trim($path, '"'), "'")));
+        return ($path && is_file($path));
     }
 }

--- a/src/Cores/FileSystem.php
+++ b/src/Cores/FileSystem.php
@@ -6,8 +6,8 @@ class FileSystem
 {
     /**
      * @param string $path
-     * 
-     * @return string
+     *
+     * @return bool
      */
     public function isValid(string $path): bool
     {
@@ -16,21 +16,21 @@ class FileSystem
 
     /**
      * @param string $path
-     * 
-     * @return string
+     *
+     * @return bool
      */
     public function isDir(string $path): bool
     {
-        return ($path && is_dir($path));
+        return ($path && is_dir(trim(trim($path, '"'), "'")));
     }
 
     /**
      * @param string $path
-     * 
-     * @return string
+     *
+     * @return bool
      */
     public function isFile(string $path): bool
     {
-        return ($path && is_file($path));
+        return ($path && is_file(trim(trim($path, '"'), "'")));
     }
 }

--- a/src/Handlers/ConvertHandler.php
+++ b/src/Handlers/ConvertHandler.php
@@ -31,7 +31,17 @@ class ConvertHandler extends Handler implements HandlerInterface
             }
 
             $tmpFile = $this->getTmpFile();
-            $output = shell_exec($this->optionsToCommand(sprintf(GhostscriptConstant::CONVERT_COMMAND, $this->getConfig()->getBinPath(), $version, $tmpFile, $file)));
+            $output = shell_exec(
+                $this->optionsToCommand(
+                    sprintf(
+                        GhostscriptConstant::CONVERT_COMMAND,
+                        $this->getConfig()->getBinPath(),
+                        $version,
+                        escapeshellarg($tmpFile),
+                        escapeshellarg($file)
+                    )
+                )
+            );
             if ($output) {
                 throw new Exception('Failed to convert ' . $file . ', because ' . $output);
             }

--- a/src/Handlers/Handler.php
+++ b/src/Handlers/Handler.php
@@ -28,7 +28,7 @@ class Handler
 
     /**
      * @param Config $config
-     * 
+     *
      * @return void
      */
     public function setConfig(Config $config): void
@@ -46,7 +46,7 @@ class Handler
 
     /**
      * @param array $options
-     * 
+     *
      * @return void
      */
     public function setOptions(array $options): void
@@ -96,8 +96,8 @@ class Handler
 
     /**
      * @param bool $isForceClear
-     * @param int $days
-     * 
+     * @param int  $days
+     *
      * @return void
      */
     public function clearTmpFiles(bool $isForceClear = false, int $days = 7): void
@@ -125,7 +125,7 @@ class Handler
 
     /**
      * @param string $command
-     * 
+     *
      * @return string
      */
     public function optionsToCommand(string $command): string
@@ -133,13 +133,13 @@ class Handler
         $options = $this->getOptions();
 
         return (!empty($options)) ? $command .= ' ' . implode(' ', array_map(function ($key, $value) {
-            return is_numeric($key) ? $value : $key . '=' . $value;
-        }, array_keys($options), $options)) : $command;
+                return is_numeric($key) ? $value : $key . '=' . $value;
+            }, array_keys($options), $options)) : $command;
     }
 
     /**
      * @param string $file
-     * 
+     *
      * @return int
      */
     public function getPdfTotalPage(string $file): int
@@ -153,7 +153,13 @@ class Handler
                 throw new Exception($file . ' is not PDF.');
             }
 
-            $output = shell_exec(sprintf(GhostscriptConstant::TOTAL_PAGE_COMMAND, $this->getConfig()->getBinPath(), $file));
+            $output = shell_exec(
+                sprintf(
+                    GhostscriptConstant::TOTAL_PAGE_COMMAND,
+                    $this->getConfig()->getBinPath(),
+                    $file
+                )
+            );
 
             return ($output) ? (int)$output : 0;
         } catch (Exception $e) {
@@ -165,7 +171,7 @@ class Handler
 
     /**
      * @param string $file
-     * 
+     *
      * @return bool
      */
     public function isPdf(string $file): bool
@@ -174,6 +180,6 @@ class Handler
             return false;
         }
 
-        return (finfo_file(finfo_open(FILEINFO_MIME_TYPE), $file) === 'application/pdf');
+        return (mime_content_type($file) === 'application/pdf');
     }
 }

--- a/src/Handlers/MergeHandler.php
+++ b/src/Handlers/MergeHandler.php
@@ -26,9 +26,9 @@ class MergeHandler extends Handler implements HandlerInterface
 
     /**
      * @param array ...$arguments
-     * 
+     *
      * @return string
-     * 
+     *
      * @throws Exception
      */
     public function execute(...$arguments): string
@@ -55,7 +55,18 @@ class MergeHandler extends Handler implements HandlerInterface
                 return true;
             });
 
-            $output = shell_exec($this->optionsToCommand(sprintf(GhostscriptConstant::MERGE_COMMAND, $this->getConfig()->getBinPath(), $file, implode(' ', $files))));
+            $output = shell_exec(
+                $this->optionsToCommand(
+                    sprintf(
+                        GhostscriptConstant::MERGE_COMMAND,
+                        $this->getConfig()->getBinPath(),
+                        escapeshellarg($file),
+                        implode(' ', array_map(function ($value) {
+                            return escapeshellarg($value);
+                        }, $files))
+                    )
+                )
+            );
             if ($output) {
                 throw new Exception('Failed to merge ' . $file . ', because ' . $output);
             }

--- a/src/Handlers/SplitHandler.php
+++ b/src/Handlers/SplitHandler.php
@@ -12,9 +12,9 @@ class SplitHandler extends Handler implements HandlerInterface
 {
     /**
      * @param array ...$arguments
-     * 
+     *
      * @return array
-     * 
+     *
      * @throws Exception
      */
     public function execute(...$arguments): array
@@ -30,7 +30,18 @@ class SplitHandler extends Handler implements HandlerInterface
             }
 
             (!$this->getConfig()->getFileSystem()->isDir($path)) && mkdir($path, 0755);
-            $output = shell_exec($this->optionsToCommand(sprintf(GhostscriptConstant::SPLIT_COMMAND, $this->getConfig()->getBinPath(), 1, $totalPage, PathHelper::convertPathSeparator($path . GhostscriptConstant::SPLIT_FILENAME), $file)));
+            $output = shell_exec(
+                $this->optionsToCommand(
+                    sprintf(
+                        GhostscriptConstant::SPLIT_COMMAND,
+                        $this->getConfig()->getBinPath(),
+                        1,
+                        $totalPage,
+                        escapeshellarg(PathHelper::convertPathSeparator($path . GhostscriptConstant::SPLIT_FILENAME)),
+                        escapeshellarg($file)
+                    )
+                )
+            );
             if ($output) {
                 throw new Exception('Failed to merge ' . $file . ', because ' . $output);
             }

--- a/src/Helpers/PathHelper.php
+++ b/src/Helpers/PathHelper.php
@@ -4,6 +4,7 @@ namespace Ordinary9843\Helpers;
 
 class PathHelper
 {
+
     /**
      * @param string $path
      *
@@ -11,12 +12,6 @@ class PathHelper
      */
     public static function convertPathSeparator(string $path): string
     {
-        $path = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $path);
-
-        if (strpos($path, ' ') !== false) {
-            $path = escapeshellarg($path);
-        }
-
-        return $path;
+        return str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $path);
     }
 }

--- a/src/Helpers/PathHelper.php
+++ b/src/Helpers/PathHelper.php
@@ -6,11 +6,17 @@ class PathHelper
 {
     /**
      * @param string $path
-     * 
+     *
      * @return string
      */
     public static function convertPathSeparator(string $path): string
     {
-        return str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $path);
+        $path = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $path);
+
+        if (strpos($path, ' ') !== false) {
+            $path = escapeshellarg($path);
+        }
+
+        return $path;
     }
 }

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests;
+
+use Dotenv\Dotenv;
+use PHPUnit\Framework\TestCase;
+
+abstract class BaseTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $dotenv = Dotenv::createImmutable(dirname(__DIR__));
+        $dotenv->safeLoad();
+
+        parent::setUp();
+    }
+
+    /**
+     * @param string $key
+     * @param string $default
+     *
+     * @return string|bool|int|float|null
+     */
+    protected function getEnv(string $key, string $default = '')
+    {
+        return $_ENV[$key] ?? $default;
+    }
+}

--- a/tests/Configs/ConfigTest.php
+++ b/tests/Configs/ConfigTest.php
@@ -3,11 +3,11 @@
 namespace Tests\Configs;
 
 use Exception;
-use PHPUnit\Framework\TestCase;
 use Ordinary9843\Configs\Config;
 use ordinary9843\Cores\FileSystem;
+use Tests\BaseTest;
 
-class ConfigTest extends TestCase
+class ConfigTest extends BaseTest
 {
     /**
      * @return void
@@ -22,7 +22,7 @@ class ConfigTest extends TestCase
      */
     public function testSetBinPathShouldEqualGetBinPath(): void
     {
-        $binPath = '/usr/bin/gs';
+        $binPath = $this->getEnv('GS_BIN_PATH');
         $config = new Config();
         $config->setBinPath($binPath);
         $this->assertEquals($binPath, $config->getBinPath());
@@ -41,6 +41,8 @@ class ConfigTest extends TestCase
 
     /**
      * @return void
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     * @throws Exception
      */
     public function testBinPathShouldExist(): void
     {
@@ -54,6 +56,7 @@ class ConfigTest extends TestCase
 
     /**
      * @return void
+     * @throws \PHPUnit\Framework\MockObject\Exception
      */
     public function testBinPathShouldNotExist(): void
     {

--- a/tests/Cores/FileSystemTest.php
+++ b/tests/Cores/FileSystemTest.php
@@ -2,10 +2,10 @@
 
 namespace Tests\Cores;
 
-use PHPUnit\Framework\TestCase;
 use ordinary9843\Cores\FileSystem;
+use Tests\BaseTest;
 
-class FileSystemTest extends TestCase
+class FileSystemTest extends BaseTest
 {
     /**
      * @return void

--- a/tests/GhostscriptTest.php
+++ b/tests/GhostscriptTest.php
@@ -4,16 +4,15 @@ namespace Tests;
 
 use Exception;
 use Ordinary9843\Ghostscript;
-use PHPUnit\Framework\TestCase;
 
-class GhostscriptTest extends TestCase
+class GhostscriptTest extends BaseTest
 {
     /**
      * @return void
      */
     public function testConvertWithExistFileShouldSucceed(): void
     {
-        $this->assertIsString((new Ghostscript('/usr/bin/gs'))->convert(dirname(__DIR__, 2) . '/files/test.pdf', 1.5));
+        $this->assertIsString((new Ghostscript($this->getEnv('GS_BIN_PATH')))->convert(dirname(__DIR__, 2) . '/files/test.pdf', 1.5));
     }
 
     /**
@@ -21,7 +20,7 @@ class GhostscriptTest extends TestCase
      */
     public function testGuessWithExistFileShouldSucceed(): void
     {
-        $this->assertIsFloat((new Ghostscript('/usr/bin/gs'))->guess(dirname(__DIR__, 2) . '/files/test.pdf'));
+        $this->assertIsFloat((new Ghostscript($this->getEnv('GS_BIN_PATH')))->guess(dirname(__DIR__, 2) . '/files/test.pdf'));
     }
 
     /**
@@ -29,7 +28,7 @@ class GhostscriptTest extends TestCase
      */
     public function testMergeWithExistFilesShouldSucceed(): void
     {
-        $this->assertIsString((new Ghostscript('/usr/bin/gs'))->merge(dirname(__DIR__, 2) . '/files/test.pdf', [
+        $this->assertIsString((new Ghostscript($this->getEnv('GS_BIN_PATH')))->merge(dirname(__DIR__, 2) . '/files/test.pdf', [
             dirname(__DIR__, 2) . '/files/part_1.pdf',
             dirname(__DIR__, 2) . '/files/part_2.pdf',
             dirname(__DIR__, 2) . '/files/part_3.pdf'
@@ -41,7 +40,7 @@ class GhostscriptTest extends TestCase
      */
     public function testSplitWithExistFilesShouldSucceed(): void
     {
-        $this->assertIsArray((new Ghostscript('/usr/bin/gs'))->split(dirname(__DIR__, 2) . '/files/test.pdf', dirname(__DIR__, 2) . '/files/split'));
+        $this->assertIsArray((new Ghostscript($this->getEnv('GS_BIN_PATH')))->split(dirname(__DIR__, 2) . '/files/test.pdf', dirname(__DIR__, 2) . '/files/split'));
     }
 
     /**
@@ -50,7 +49,7 @@ class GhostscriptTest extends TestCase
     public function testSetBinPathShouldEqualGetBinPath(): void
     {
         $ghostscript = new Ghostscript();
-        $binPath = '/usr/bin/gs';
+        $binPath = $this->getEnv('GS_BIN_PATH');
         $ghostscript->setBinPath($binPath);
         $this->assertEquals($binPath, $ghostscript->getBinPath());
     }

--- a/tests/Handlers/GuessHandlerTest.php
+++ b/tests/Handlers/GuessHandlerTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\Handlers;
 
-use PHPUnit\Framework\TestCase;
 use Ordinary9843\Handlers\GuessHandler;
 use Ordinary9843\Constants\MessageConstant;
+use Tests\BaseTest;
 
-class GuessHandlerTest extends TestCase
+class GuessHandlerTest extends BaseTest
 {
     /**
      * @return void
@@ -15,7 +15,7 @@ class GuessHandlerTest extends TestCase
     {
         $file = dirname(__DIR__, 2) . '/files/test.pdf';
         $guessHandler = new GuessHandler();
-        $guessHandler->getConfig()->setBinPath('/usr/bin/gs');
+        $guessHandler->getConfig()->setBinPath($this->getEnv('GS_BIN_PATH'));
         $this->assertEquals(1.5, $guessHandler->execute($file));
         $this->assertFileExists($file);
         $this->assertEmpty($guessHandler->getMessages()[MessageConstant::MESSAGE_TYPE_ERROR]);
@@ -28,9 +28,9 @@ class GuessHandlerTest extends TestCase
     {
         $file = dirname(__DIR__, 2) . '/files/part_4.pdf';
         $guessHandler = new GuessHandler();
-        $guessHandler->getConfig()->setBinPath('/usr/bin/gs');
+        $guessHandler->getConfig()->setBinPath($this->getEnv('GS_BIN_PATH'));
         $this->assertEquals(0.0, $guessHandler->execute($file));
-        $this->assertFileNotExists($file);
+        $this->assertFileDoesNotExist($file);
         $this->assertNotEmpty($guessHandler->getMessages()[MessageConstant::MESSAGE_TYPE_ERROR]);
     }
 }

--- a/tests/Handlers/HandlerTest.php
+++ b/tests/Handlers/HandlerTest.php
@@ -2,12 +2,12 @@
 
 namespace Tests\Handlers;
 
-use PHPUnit\Framework\TestCase;
 use Ordinary9843\Configs\Config;
 use Ordinary9843\Cores\FileSystem;
 use Ordinary9843\Handlers\Handler;
+use Tests\BaseTest;
 
-class HandlerTest extends TestCase
+class HandlerTest extends BaseTest
 {
     /**
      * @return void
@@ -23,7 +23,7 @@ class HandlerTest extends TestCase
     public function testSetConfigShouldEqualGetConfig(): void
     {
         $config = new Config([
-            'binPath' => '/usr/bin/gs',
+            'binPath' => $this->getEnv('GS_BIN_PATH'),
             'tmpPath' => sys_get_temp_dir()
         ]);
         $handler = new Handler();
@@ -61,7 +61,7 @@ class HandlerTest extends TestCase
     public function testTmpFileShouldHaveCorrectFormat(): void
     {
         $handler = new Handler();
-        $this->assertStringStartsWith('/tmp/ghostscript_tmp_file_', $handler->getTmpFile());
+        $this->assertStringContainsString('/ghostscript_tmp_file_', $handler->getTmpFile());
         $this->assertStringEndsWith('.pdf', $handler->getTmpFile());
     }
 
@@ -97,7 +97,7 @@ class HandlerTest extends TestCase
     {
         $file = dirname(__DIR__, 2) . '/files/test.pdf';
         $config = new Config([
-            'binPath' => '/usr/bin/gs'
+            'binPath' => $this->getEnv('GS_BIN_PATH')
         ]);
         $handler = new Handler($config);
         $this->assertGreaterThan(0, $handler->getPdfTotalPage($file));
@@ -105,6 +105,7 @@ class HandlerTest extends TestCase
 
     /**
      * @return void
+     * @throws \PHPUnit\Framework\MockObject\Exception
      */
     public function testGetPdfTotalPageShouldReturnLessThanOrEqualZero(): void
     {
@@ -112,7 +113,7 @@ class HandlerTest extends TestCase
         $fileSystem->method('isFile')->willReturn(false);
         $file = dirname(__DIR__, 2) . '/files/test.pdf';
         $handler = new Handler(new Config([
-            'binPath' => '/usr/bin/gs',
+            'binPath' => $this->getEnv('GS_BIN_PATH'),
             'fileSystem' => $fileSystem
         ]));
         $this->assertLessThanOrEqual(0, $handler->getPdfTotalPage($file));
@@ -123,8 +124,7 @@ class HandlerTest extends TestCase
         $this->assertLessThanOrEqual(0, $handler->getPdfTotalPage($file));
 
         $handler = $this->getMockBuilder(Handler::class)
-            ->setConstructorArgs([new Config(['binPath' => '/usr/bin/gs'])])
-            ->setMethods(['isPdf'])
+            ->onlyMethods(['isPdf'])
             ->getMock();
         $handler->method('isPdf')->willReturn(false);
         $this->assertLessThanOrEqual(0, $handler->getPdfTotalPage($file));

--- a/tests/Handlers/MergeHandlerTest.php
+++ b/tests/Handlers/MergeHandlerTest.php
@@ -2,12 +2,13 @@
 
 namespace Tests\Handlers;
 
-use PHPUnit\Framework\TestCase;
+use Exception;
 use Ordinary9843\Configs\Config;
 use Ordinary9843\Handlers\MergeHandler;
 use Ordinary9843\Constants\MessageConstant;
+use Tests\BaseTest;
 
-class MergeHandlerTest extends TestCase
+class MergeHandlerTest extends BaseTest
 {
     /**
      * @return void
@@ -19,12 +20,13 @@ class MergeHandlerTest extends TestCase
 
     /**
      * @return void
+     * @throws Exception
      */
     public function testExecuteWithExistFileShouldSucceed(): void
     {
         $file = dirname(__DIR__, 2) . '/files/test.pdf';
         $mergeHandler = new MergeHandler();
-        $mergeHandler->getConfig()->setBinPath('/usr/bin/gs');
+        $mergeHandler->getConfig()->setBinPath($this->getEnv('GS_BIN_PATH'));
         $mergeHandler->execute($file, [
             dirname(__DIR__, 2) . '/files/part_1.pdf',
             dirname(__DIR__, 2) . '/files/part_2.pdf',
@@ -36,12 +38,13 @@ class MergeHandlerTest extends TestCase
 
     /**
      * @return void
+     * @throws Exception
      */
     public function testExecuteWithNotExistFileShouldReturnErrorMessage(): void
     {
         $file = dirname(__DIR__, 2) . '/files/test.pdf';
         $mergeHandler = new MergeHandler();
-        $mergeHandler->getConfig()->setBinPath('/usr/bin/gs');
+        $mergeHandler->getConfig()->setBinPath($this->getEnv('GS_BIN_PATH'));
         $mergeHandler->execute($file, [
             dirname(__DIR__, 2) . '/files/part_1.pdf',
             dirname(__DIR__, 2) . '/files/part_2.pdf',
@@ -54,14 +57,15 @@ class MergeHandlerTest extends TestCase
 
     /**
      * @return void
+     * @throws Exception
      */
     public function testExecuteWithNotPdfShouldReturnErrorMessage(): void
     {
         $file = dirname(__DIR__, 2) . '/files/test.pdf';
         $mergeHandler = $this->getMockBuilder(MergeHandler::class)
-            ->setConstructorArgs([new Config(['binPath' => '/usr/bin/gs'])])
-            ->setMethods(['isPdf'])
+            ->onlyMethods(['isPdf', 'getConfig'])
             ->getMock();
+        $mergeHandler->method('getConfig')->willReturn(new Config(['binPath' => $this->getEnv('GS_BIN_PATH')]));
         $mergeHandler->method('isPdf')->willReturn(false);
         $mergeHandler->execute($file, [
             dirname(__DIR__, 2) . '/files/part_1.pdf',
@@ -74,12 +78,13 @@ class MergeHandlerTest extends TestCase
 
     /**
      * @return void
+     * @throws Exception
      */
     public function testExecuteFailedShouldReturnErrorMessage(): void
     {
         $file = dirname(__DIR__, 2) . '/files/test.pdf';
         $mergeHandler = new MergeHandler(new Config([
-            'binPath' => '/usr/bin/gs'
+            'binPath' => $this->getEnv('GS_BIN_PATH')
         ]));
         $mergeHandler->setOptions([
             'test' => true

--- a/tests/Handlers/SplitHandlerTest.php
+++ b/tests/Handlers/SplitHandlerTest.php
@@ -2,12 +2,12 @@
 
 namespace Tests\Handlers;
 
-use PHPUnit\Framework\TestCase;
 use Ordinary9843\Configs\Config;
 use Ordinary9843\Handlers\SplitHandler;
 use Ordinary9843\Constants\MessageConstant;
+use Tests\BaseTest;
 
-class SplitHandlerTest extends TestCase
+class SplitHandlerTest extends BaseTest
 {
     /**
      * @return void
@@ -19,24 +19,26 @@ class SplitHandlerTest extends TestCase
 
     /**
      * @return void
+     * @throws \Exception
      */
     public function testExecuteWithExistFileShouldSucceed(): void
     {
         $splitHandler = new SplitHandler();
-        $splitHandler->getConfig()->setBinPath('/usr/bin/gs');
+        $splitHandler->getConfig()->setBinPath($this->getEnv('GS_BIN_PATH'));
         $this->assertCount(3, $splitHandler->execute(dirname(__DIR__, 2) . '/files/test.pdf', '/tmp/mock/files'));
         $this->assertEmpty($splitHandler->getMessages()[MessageConstant::MESSAGE_TYPE_ERROR]);
     }
 
     /**
      * @return void
+     * @throws \Exception
      */
     public function testExecuteWithNotExistFileShouldReturnErrorMessage(): void
     {
         $splitHandler = $this->getMockBuilder(SplitHandler::class)
-            ->setConstructorArgs([new Config(['binPath' => '/usr/bin/gs'])])
-            ->setMethods(['getPdfTotalPage'])
+            ->onlyMethods(['getPdfTotalPage', 'getConfig'])
             ->getMock();
+        $splitHandler->method('getConfig')->willReturn(new Config(['binPath' => $this->getEnv('GS_BIN_PATH')]));
         $splitHandler->method('getPdfTotalPage')->willReturn(0);
         $this->assertCount(0, $splitHandler->execute(dirname(__DIR__, 2) . '/files/test.pdf', '/tmp/mock/files'));
         $this->assertNotEmpty($splitHandler->getMessages()[MessageConstant::MESSAGE_TYPE_ERROR]);
@@ -44,11 +46,12 @@ class SplitHandlerTest extends TestCase
 
     /**
      * @return void
+     * @throws \Exception
      */
     public function testExecuteFailedShouldReturnErrorMessage(): void
     {
         $splitHandler = new SplitHandler(new Config([
-            'binPath' => '/usr/bin/gs'
+            'binPath' => $this->getEnv('GS_BIN_PATH')
         ]));
         $splitHandler->setOptions([
             'test' => true

--- a/tests/Helpers/PathHelperTest.php
+++ b/tests/Helpers/PathHelperTest.php
@@ -21,8 +21,5 @@ class PathHelperTest extends BaseTest
     public function testPathShouldEqualOriginPathAfterConversion(): void
     {
         $this->assertEquals(implode(DIRECTORY_SEPARATOR, ['usr', 'bin', 'gs']), PathHelper::convertPathSeparator('usr/bin/gs'));
-        $this->assertEquals("'usr/bin/sub path with spaces/gs'", PathHelper::convertPathSeparator('usr/bin/sub path with spaces/gs'));
-        $this->assertEquals('usr/bin/sub-path-with-separator/gs', PathHelper::convertPathSeparator('usr/bin/sub-path-with-separator/gs'));
-        $this->assertEquals('usr/bin/sub_path_with_underscore/gs', PathHelper::convertPathSeparator('usr/bin/sub_path_with_underscore/gs'));
     }
 }

--- a/tests/Helpers/PathHelperTest.php
+++ b/tests/Helpers/PathHelperTest.php
@@ -21,5 +21,8 @@ class PathHelperTest extends TestCase
     public function testPathShouldEqualOriginPathAfterConversion(): void
     {
         $this->assertEquals(implode(DIRECTORY_SEPARATOR, ['usr', 'bin', 'gs']), PathHelper::convertPathSeparator('usr/bin/gs'));
+        $this->assertEquals("'usr/bin/sub path with spaces/gs'", PathHelper::convertPathSeparator('usr/bin/sub path with spaces/gs'));
+        $this->assertEquals('usr/bin/sub-path-with-separator/gs', PathHelper::convertPathSeparator('usr/bin/sub-path-with-separator/gs'));
+        $this->assertEquals('usr/bin/sub_path_with_underscore/gs', PathHelper::convertPathSeparator('usr/bin/sub_path_with_underscore/gs'));
     }
 }

--- a/tests/Helpers/PathHelperTest.php
+++ b/tests/Helpers/PathHelperTest.php
@@ -2,10 +2,10 @@
 
 namespace Tests\Helpers;
 
-use PHPUnit\Framework\TestCase;
 use Ordinary9843\Helpers\PathHelper;
+use Tests\BaseTest;
 
-class PathHelperTest extends TestCase
+class PathHelperTest extends BaseTest
 {
     /**
      * @return void

--- a/tests/Traits/MessageTraitTest.php
+++ b/tests/Traits/MessageTraitTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Tests;
+namespace Tests\Traits;
 
-use PHPUnit\Framework\TestCase;
 use Ordinary9843\Constants\MessageConstant;
 use Ordinary9843\Traits\MessageTrait;
+use Tests\BaseTest;
 
-class MessageTraitTest extends TestCase
+class MessageTraitTest extends BaseTest
 {
     use MessageTrait;
 


### PR DESCRIPTION
Hi ordinary9843,

I encountered a path issue with the library when merging PDF files located in a folder containing spaces on MacOS. The path sent to Ghostscript was not properly escaped, leading to an invalid file path. I've implemented a fix for this. At the same time, I added an environment variable for the GS bin path to execute the tests. Additionally, I changed the `setMethods` of the mocks to `onlyMethods`, as the former is deprecated and the tests were failing.

I tried to adhere to the naming convention of the repository.

I am available for further discussion.

Looking forward to hearing from you,
Dimer47