### PR TITLE
Update BaseHandler.php

### DIFF
--- a/src/Handlers/BaseHandler.php
+++ b/src/Handlers/BaseHandler.php
@@ -151,7 +151,7 @@ class BaseHandler implements HandlerInterface
      */
     public function isPdf(string $file): bool
     {
-        if (pathinfo($file, PATHINFO_EXTENSION) !== 'pdf') {
+        if (strcasecmp(pathinfo($file, PATHINFO_EXTENSION), 'pdf') !== 0) {
             return false;
         }
 


### PR DESCRIPTION
### Problem:
The isPdf function uses a string comparison of the file extension but it is not case insensitive so will fail when the extension is not lowercase:
```
var_dump(isPdf('pdf')); // TRUE
var_dump(isPdf('PDF')); // FALSE
var_dump(isPdf('pDf')); // FALSE
var_dump(isPdf('pdF')); // FALSE
var_dump(isPdf('PdF')); // FALSE
```

### Proposed solution:
Using the `strcasecmp` function to compare the file extensions in a case insensitive mode:
```
var_dump(isPdf('pdf')); // TRUE
var_dump(isPdf('PDF')); // TRUE
var_dump(isPdf('pDf')); // TRUE
var_dump(isPdf('pdF')); // TRUE
var_dump(isPdf('PdF')); // TRUE
```